### PR TITLE
ci: security & privacy scan on every PR/push

### DIFF
--- a/.github/workflows/security-privacy-scan.yml
+++ b/.github/workflows/security-privacy-scan.yml
@@ -1,0 +1,87 @@
+name: Security & Privacy Scan
+
+# Runs on every pull request (any base branch / any environment) and on direct
+# pushes to any branch. Two jobs:
+#   * secrets  — gitleaks, scans full git history. FAILS the check on a hit.
+#   * privacy  — generic personal-data (PII) patterns. Annotates as WARNINGS
+#                (non-blocking) so it never surprises-breaks a PR; flip
+#                `continue-on-error` to false to make it blocking.
+
+on:
+  pull_request:
+  push:
+    # PRs are covered by pull_request; here we also scan direct commits/merges
+    # to long-lived environment branches. This avoids double-runs on feature
+    # branches that already have an open PR.
+    branches: [main, master, develop, dev, staging, stage, production, prod, release]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sec-privacy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  secrets:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history so historical leaks are caught
+      - name: Install gitleaks
+        run: |
+          VERSION=8.21.2
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${VERSION}/gitleaks_${VERSION}_linux_x64.tar.gz" \
+            | tar -xz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Scan repository (full history)
+        run: gitleaks detect --source . --redact --verbose --exit-code 1
+
+  privacy:
+    name: Personal-data (PII) scan
+    runs-on: ubuntu-latest
+    continue-on-error: true      # WARNING-only by default; set false to block
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Scan changed content for personal data
+        shell: bash
+        run: |
+          set -uo pipefail
+          # On a PR, scan only the diff vs the base; otherwise scan the tree.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="${{ github.event.pull_request.base.sha }}"
+            files=$(git diff --name-only "$base"...HEAD | grep -viE '(^|/)(node_modules|dist|build|\.git)/' || true)
+          else
+            files=$(git ls-files | grep -viE '(^|/)(node_modules|dist|build)/' || true)
+          fi
+          [ -z "$files" ] && { echo "No files to scan."; exit 0; }
+
+          # Generic, name-free PII patterns. Deliberately does NOT hard-code any
+          # real name/email so the workflow itself leaks nothing when public.
+          declare -A P=(
+            [email]='[A-Za-z0-9._%+-]+@(gmail|hotmail|outlook|yahoo|icloud|proton(mail)?|live|me|aol)\.[A-Za-z.]{2,}'
+            [phone_jp]='\+81[- ]?[0-9]{1,4}[- ]?[0-9]{2,4}[- ]?[0-9]{3,4}'
+            [phone_intl]='\+[1-9][0-9]{0,2}[- ]?\(?[0-9]{2,4}\)?[- ]?[0-9]{3,4}[- ]?[0-9]{3,4}'
+            [credit_card]='\b(?:4[0-9]{12}(?:[0-9]{3})?|5[1-5][0-9]{14}|3[47][0-9]{13})\b'
+            [jp_mynumber]='\b[0-9]{4}[- ]?[0-9]{4}[- ]?[0-9]{4}\b'
+            [ssn]='\b[0-9]{3}-[0-9]{2}-[0-9]{4}\b'
+            [ip_public]='\b(?!10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.|127\.)[0-9]{1,3}(\.[0-9]{1,3}){3}\b'
+          )
+          hits=0
+          while IFS= read -r f; do
+            [ -f "$f" ] || continue
+            case "$f" in *.png|*.jpg|*.jpeg|*.gif|*.pdf|*.ico|*.woff*|*.ttf|*.zip|*.lock|*-lock.json) continue;; esac
+            for label in "${!P[@]}"; do
+              while IFS=: read -r ln text; do
+                [ -z "${ln:-}" ] && continue
+                echo "::warning file=$f,line=$ln::Possible PII ($label): ${text:0:80}"
+                hits=$((hits+1))
+              done < <(grep -nEI "${P[$label]}" "$f" 2>/dev/null | head -20)
+            done
+          done <<< "$files"
+          echo "PII scan complete: $hits potential match(es). Review the warnings above."


### PR DESCRIPTION
## What
Adds `.github/workflows/security-privacy-scan.yml` — runs on **every pull request and on pushes to environment branches** (main/master/develop/staging/production/release).

**Jobs:**
- **secrets** — gitleaks over full git history (blocking on hit).
- **privacy** — generic PII pattern scan: personal emails, phone numbers, card/SSN/MyNumber-like strings, public IPs. Warning-only by default (`continue-on-error: true`); set to `false` to enforce.

PII patterns are generic (no real name/email hard-coded) so the workflow leaks nothing in public repos. Validated on nilpost/focus-timer#3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)